### PR TITLE
Fix bug with withTranslationHOC and weird scopes.

### DIFF
--- a/src/extractors/withTranslationHOC.ts
+++ b/src/extractors/withTranslationHOC.ts
@@ -34,10 +34,16 @@ function findWithTranslationHOCCallExpression(
   if (Array.isArray(functionIdentifier) || !functionIdentifier.isIdentifier())
     return null;
 
+  const bindings =
+    path.parentPath.scope.bindings[functionIdentifier.node.name];
+
+  // Likely an anonymous function not in a normal scope.
+  // e.g. "['foo', function myFunction() { return 'foo'; }]"
+  // Let's just ignore such case.
+  if (!bindings) return null;
+
   // Try to find a withTranslation() call in parent scope
-  for (const refPath of path.parentPath.scope.bindings[
-    functionIdentifier.node.name
-  ].referencePaths) {
+  for (const refPath of bindings.referencePaths) {
     const callExpr: BabelCore.NodePath = refPath.findParent(parentPath => {
       if (!parentPath.isCallExpression()) return false;
       const callee = parentPath.get('callee');

--- a/tests/__fixtures__/testWithTranslationHOC/scope.js
+++ b/tests/__fixtures__/testWithTranslationHOC/scope.js
@@ -1,0 +1,11 @@
+import { withTranslation } from 'react-i18next';
+
+// This function isn't in the main scope.
+// This should not confuse the parser.
+[function MyComponent0(props) {
+  return <p>{props.t('noob')}</p>
+}]
+
+t('pro')
+
+withTranslation()(MyComponent0);

--- a/tests/__fixtures__/testWithTranslationHOC/scope.json
+++ b/tests/__fixtures__/testWithTranslationHOC/scope.json
@@ -1,0 +1,7 @@
+{
+  "description": "test that withTranslationHOC don't get confused with weird scopes",
+  "pluginOptions": {},
+  "expectValues": {
+      "pro": ""
+  }
+}


### PR DESCRIPTION
When a function was declared in an array, the plugin would crash.