### PR TITLE
Fix crash with t function default value.

### DIFF
--- a/src/extractors/tFunction.ts
+++ b/src/extractors/tFunction.ts
@@ -54,7 +54,7 @@ function parseTCallOptions(
 
   // Try brutal evaluation first.
   const optsEvaluation = evaluateIfConfident(path);
-  if (optsEvaluation !== null) {
+  if (optsEvaluation !== null && typeof optsEvaluation === 'object') {
     res.contexts = 'context' in optsEvaluation;
     res.hasCount = 'count' in optsEvaluation;
 

--- a/tests/__fixtures__/testTFunction/withOpts.js
+++ b/tests/__fixtures__/testTFunction/withOpts.js
@@ -3,3 +3,4 @@ t('withNonEvaluableOpts', {count: cnt, context: ctx});
 t('withSimpleIdentifiers', {count, context});
 t('onlyCount', {count});
 t('onlyContext', {context});
+t('onlyDefaultValue', 'some default value');

--- a/tests/__fixtures__/testTFunction/withOpts.json
+++ b/tests/__fixtures__/testTFunction/withOpts.json
@@ -22,6 +22,7 @@
     "withSimpleIdentifiers_female_plural": "",
     "onlyCount": "",
     "onlyCount_plural": "",
+    "onlyDefaultValue": "",
     "onlyContext": "",
     "onlyContext_male": "",
     "onlyContext_female": ""


### PR DESCRIPTION
When the second argument of the t function is just a string, the program
would crash. It's actually possible to specify a default value as a
string and not in an object.

See https://www.i18next.com/translation-function/essentials#passing-a-default-value

Fixes #21

ping @DanielHuisman