### PR TITLE
Fix skipped keys with useTranslation hook.

### DIFF
--- a/tests/__fixtures__/testUseTranslationHook/namespace.js
+++ b/tests/__fixtures__/testUseTranslationHook/namespace.js
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 export function MyComponent1() {
   const [t] = useTranslation('ns0');
-  return <p>{t('key0')}</p>
+  return <p>{t('key0')}{t('key1')}</p>
 }
 
 export function MyComponent2() {

--- a/tests/__fixtures__/testUseTranslationHook/namespace.json
+++ b/tests/__fixtures__/testUseTranslationHook/namespace.json
@@ -2,7 +2,7 @@
   "description": "test namespace extraction of useTranslation hook",
   "pluginOptions": {},
   "expectValues": [
-    [{"key0": ""}, {"ns": "ns0"}],
+    [{"key0": "", "key1": ""}, {"ns": "ns0"}],
     [{"key0": ""}, {"ns": "ns1"}],
     [{"key0": ""}, {"ns": "ns2"}]
   ]


### PR DESCRIPTION
The bug was introduced in #15 and was related to the keys priority
mechanism. When adding a key from useTranslation hook extractor, any
subsequent key coming from the same useTranslation hook would be
considered as conflicting.

Fixes #29