### PR TITLE
remove node depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "@types/i18next": "^12.1.0",
     "@types/node": "^12.0.8",
     "i18next": "^17.0.4",
-    "json-stable-stringify": "^1.0.1",
-    "node": "^12.4.0"
+    "json-stable-stringify": "^1.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3497,11 +3497,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-bin-setup@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/node-bin-setup/-/node-bin-setup-1.0.6.tgz#4b5c9bb937ece702d7069b36ca78af4684677528"
-  integrity sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3545,13 +3540,6 @@ node-releases@^1.1.23:
   integrity sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==
   dependencies:
     semver "^5.3.0"
-
-node@^12.4.0:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/node/-/node-12.6.0.tgz#19cff21c4753c771055392a06e36076df97ee78a"
-  integrity sha512-1HxFACwgnpIukN05sh3aASsYDwJhdw4Ry34vJJquT+Q0EraI5Byi+aOYCMHMnCYK4X3xn1hJIOtRO6FTuN7+/A==
-  dependencies:
-    node-bin-setup "^1.0.0"
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
When attempting to install this package, the node dependency fails to install on an NFS mount. The issue is due to https://github.com/aredridel/node-bin-setup/blob/master/index.js#L53. It's not possible to create a hard link on an NFS mount so this step fails in my team's environment. The referenced package _could_ also use a symlink instead of a hard link, but I think it'd be better to just remove this dependency entirely. There is a [2 year old PR](https://github.com/aredridel/node-bin-setup/pull/1) open in the repository to fix the issue but it hasn't been merged.