### PR TITLE
Add instruction about node version and mkdirSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ npm run babel -f .babelrc 'src/**/*.{js,jsx,ts,tsx}'
 
 Extracted translations land in the `extractedTranslations/` directory by default.
 
-### Troubleshooting
+## Troubleshooting
 
-## Error: EEXIST: file already exists, mkdir './extractedTranslations/en'
+### Error: EEXIST: file already exists, mkdir './extractedTranslations/en'
 
 Node 10 has added native support for `mkdir` and `mkdirSync`. We use
-`mkdirSync` to create the extractedTranslations folder. If you are having this
-error, check your node version.
+`mkdirSync` to create the extractedTranslations folder. Node 8 would refuse to
+create the folder if it doesn't exist.
+
+If you are having this error, check your node version.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ npm run babel -f .babelrc 'src/**/*.{js,jsx,ts,tsx}'
 ```
 
 Extracted translations land in the `extractedTranslations/` directory by default.
+
+### Troubleshooting
+
+## Error: EEXIST: file already exists, mkdir './extractedTranslations/en'
+
+Node 10 has added native support for `mkdir` and `mkdirSync`. We use
+`mkdirSync` to create the extractedTranslations folder. If you are having this
+error, check your node version.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,3 +81,12 @@ npm run babel -f .babelrc 'src/**/*.{js,jsx,ts,tsx}'
 
 Extracted translations land in the `extractedTranslations/` directory by default.
 
+## Troubleshooting
+
+### Error: EEXIST: file already exists, mkdir './extractedTranslations/en'
+
+Node 10 has added native support for `mkdir` and `mkdirSync`. We use
+`mkdirSync` to create the extractedTranslations folder. Node 8 would refuse to
+create the folder if it doesn't exist.
+
+If you are having this error, check your node version.


### PR DESCRIPTION
Hi @gilbsgilbs 

Node 8 doesn't support mkdirSync recursive. I use node 10 in CI environments but didn't noted I was using node 8 in my local environment :)

And not only me, [others have faced the same problem](https://github.com/gilbsgilbs/babel-plugin-i18next-extract/issues/43). Do you think it would be useful to include a faq or a troubleshooting section with an entry about it?