### PR TITLE
Allow config a new line at end of extracted file

### DIFF
--- a/docs/templates/configuration.md.yml
+++ b/docs/templates/configuration.md.yml
@@ -207,3 +207,7 @@ configOptions:
     type: "number"
     description: Number of indentation space to use in extracted JSON files.
     defaultValue: "2"
+  - name: appendNewLineAtEndOfFile
+    type: "boolean"
+    description: When set to `true`, the exported file would include a new line character at the end.
+    defaultValue: "false"

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface Config {
   keyAsDefaultValueForDerivedKeys: boolean;
   discardOldKeys: boolean;
   jsonSpace: string | number;
+  appendNewLineAtEndOfFile: boolean;
 }
 
 function coalesce<T>(v: T | undefined, defaultVal: T): T {
@@ -67,5 +68,6 @@ export function parseConfig(opts: Partial<Config>): Config {
     ),
     discardOldKeys: coalesce(opts.discardOldKeys, false),
     jsonSpace: coalesce(opts.jsonSpace, 2),
+    appendNewLineAtEndOfFile: coalesce(opts.appendNewLineAtEndOfFile, false),
   };
 }

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -165,5 +165,8 @@ export default function exportTranslationKeys(
         encoding: 'utf8',
       },
     );
+    if (config.appendNewLineAtEndOfFile) {
+      fs.appendFileSync(filePath, '\n');
+    }
   }
 }

--- a/tests/exporters/exporter.test.ts
+++ b/tests/exporters/exporter.test.ts
@@ -114,4 +114,24 @@ describe('Test exporter works', () => {
       newKey2: '',
     });
   });
+
+  it('wont include a new line character at the end of the file by default', () => {
+    const outputPath = path.join(outputDir, 'new_line_at_end.json');
+    const config = parseConfig({ outputPath });
+    const key = createSimpleKey('key0');
+    exportTranslationKeys([key], 'fr', config, createExporterCache());
+    const output = fs.readFileSync(outputPath, { encoding: 'utf-8' });
+    expect(output.charAt(output.length - 1)).toEqual('}');
+    expect(fs.readJSONSync(outputPath)).toEqual({ key0: '' });
+  });
+
+  it('can include a new line character at the end of the exported file', () => {
+    const outputPath = path.join(outputDir, 'new_line_at_end.json');
+    const config = parseConfig({ outputPath, appendNewLineAtEndOfFile: true });
+    const key = createSimpleKey('key0');
+    exportTranslationKeys([key], 'fr', config, createExporterCache());
+    const output = fs.readFileSync(outputPath, { encoding: 'utf-8' });
+    expect(output.charAt(output.length - 1)).toEqual('\n');
+    expect(fs.readJSONSync(outputPath)).toEqual({ key0: '' });
+  });
 });


### PR DESCRIPTION
Hi @gilbsgilbs 

We use vim to update the translations files and it adds a newline char at the end of the file automatically.

You are writing the json-stringified content directly, without this new line. Do you mind if we have a config option to include this new line char?