### PR TITLE
 Support react-i18next "transKeepBasicHtmlNodesFor" option

### DIFF
--- a/docs/templates/configuration.md.yml
+++ b/docs/templates/configuration.md.yml
@@ -30,6 +30,12 @@ configOptions:
     type: "string|null"
     description: String you want to use to split namespace from keys. Set to `null` if you don't want to infer a namespace from key value or if you want to use keys as value. See [i18next Configuration options](https://www.i18next.com/overview/configuration-options#misc).
     defaultValue: "':'"
+  - name: transKeepBasicHtmlNodesFor
+    type: "string[]"
+    description: >
+      List of tag names that shouldn't be converted to indices when exporting `Trans` component.
+      The value of this option should reflect the react-i18next configuration in your codebase. See [react-i18next Trans Component](https://react.i18next.com/latest/trans-component#additional-options-on-i-18-next-init).
+    defaultValue: "['br', 'strong', 'i', 'p']"
   - name: i18nextInstanceNames
     type: "string[]"
     description: Possible names for your `i18next` instances. This will be used to detect `i18next.t` calls.

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export interface Config {
   contextSeparator: string;
   keySeparator: string | null;
   nsSeparator: string | null;
+  transKeepBasicHtmlNodesFor: string[];
 
   // plugin-specific options
   i18nextInstanceNames: string[];
@@ -40,6 +41,13 @@ export function parseConfig(opts: Partial<Config>): Config {
     contextSeparator: coalesce(opts.contextSeparator, '_'),
     keySeparator: coalesce(opts.keySeparator, '.'),
     nsSeparator: coalesce(opts.nsSeparator, ':'),
+    // From react-i18next: https://github.com/i18next/react-i18next/blob/90f0e44ac2710ae422f1e8b0270de95fedc6429c/react-i18next.js#L334
+    transKeepBasicHtmlNodesFor: coalesce(opts.transKeepBasicHtmlNodesFor, [
+      'br',
+      'strong',
+      'i',
+      'p',
+    ]),
 
     i18nextInstanceNames: coalesce(opts.i18nextInstanceNames, [
       'i18next',

--- a/src/extractors/transComponent.ts
+++ b/src/extractors/transComponent.ts
@@ -127,6 +127,44 @@ function parseTransComponentKeyFromAttributes(
 }
 
 /**
+ * Format the key of a JSX element.
+ *
+ * @param path node path of the JSX element to format.
+ * @param index the current index of the node being parsed.
+ * @param config plugin configuration.
+ */
+function formatJSXElementKey(
+  path: BabelCore.NodePath<BabelTypes.JSXElement>,
+  index: number,
+  config: Config,
+): string {
+  const openingElement = path.get('openingElement');
+  const closingElement = path.get('closingElement');
+  let resultTagName = `${index}`; // Tag name we will use in the exported file
+
+  const tagName = openingElement.get('name');
+  if (
+    openingElement.get('attributes').length === 0 &&
+    tagName.isJSXIdentifier() &&
+    config.transKeepBasicHtmlNodesFor.includes(tagName.node.name)
+  ) {
+    // The tag name should not be transformed to an index
+    resultTagName = tagName.node.name;
+
+    if (closingElement.node === null) {
+      // opening tag without closing tag (e.g. <br />)
+      return `<${resultTagName}/>`;
+    }
+  }
+
+  // it's nested. let's recurse.
+  return `<${resultTagName}>${parseTransComponentKeyFromChildren(
+    path,
+    config,
+  )}</${resultTagName}>`;
+}
+
+/**
  * Given the node path of a Trans component, try to extract its key from its
  *   children.
  * @param path node path of the Trans component.
@@ -234,14 +272,7 @@ function parseTransComponentKeyFromChildren(
 
     if (child.isJSXElement()) {
       // got a JSX element.
-      if (child.get('closingElement').node === null) {
-        // opening tag without closing tag (e.g. <br />)
-        result += `<${i}>`;
-        continue;
-      }
-
-      // it's nested. let's recurse.
-      result += `<${i}>${parseTransComponentKeyFromChildren(child)}</${i}>`;
+      result += formatJSXElementKey(child, i, config);
       continue;
     }
   }
@@ -268,7 +299,10 @@ export default function extractTransComponent(
   const keyEvaluationFromAttribute = parseTransComponentKeyFromAttributes(
     path,
   );
-  const keyEvaluationFromChildren = parseTransComponentKeyFromChildren(path);
+  const keyEvaluationFromChildren = parseTransComponentKeyFromChildren(
+    path,
+    config,
+  );
 
   const parsedOptions = parseTransComponentOptions(path, commentHints);
   if (parsedOptions.defaultValue === null) {

--- a/tests/__fixtures__/testTransComponent/bindings.js
+++ b/tests/__fixtures__/testTransComponent/bindings.js
@@ -16,7 +16,7 @@ function foo() {
 // As well as complex references.
 const complexRef = (
   <div>
-    <strong>Deep reference</strong>
+    <u>Deep reference</u>
   </div>
 );
 const trans1 = (

--- a/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.js
+++ b/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.js
@@ -1,0 +1,29 @@
+import {Trans} from 'react-i18next';
+
+// Tag without closing tag should not be converted to indices
+const trans0 = (
+  <Trans>
+    Trans<br />0
+  </Trans>
+);
+
+// Tag with closing tag should not be converted to indices
+const trans1 = (
+  <Trans>
+    <p>Trans 1</p>
+  </Trans>
+);
+
+// Tag with attributes should not be converted to indices
+const trans2 = (
+  <Trans>
+    <p className="fizzBuzz">Trans 2</p>
+  </Trans>
+);
+
+// Tags not set in config should be converted to indices
+const trans3 = (
+  <Trans>
+    <strong>Trans 3<hr /></strong>
+  </Trans>
+);

--- a/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.json
+++ b/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.json
@@ -1,0 +1,14 @@
+{
+  "description": "Test that HTML tags are untouched when exported for given nodes",
+  "pluginOptions": {
+    "keySeparator": null,
+    "nsSeparator": null,
+    "transKeepBasicHtmlNodesFor": ["br", "p"]
+  },
+  "expectValues": {
+    "Trans<br/>0": "Trans<br/>0",
+    "<p>Trans 1</p>": "<p>Trans 1</p>",
+    "<0>Trans 2</0>": "<0>Trans 2</0>",
+    "<0>Trans 3<1></1></0>": "<0>Trans 3<1></1></0>"
+  }
+}

--- a/tests/__fixtures__/testTransComponent/nodeConversion.js
+++ b/tests/__fixtures__/testTransComponent/nodeConversion.js
@@ -18,6 +18,6 @@ const comp1 = (
 // non-closing tags need special handling
 const comp2 = (
   <Trans>
-    Hi <strong>{{name}}<br /></strong>, how<br /> are you doing?
+    Hi <strong title={t('nameTitle')}>{{name}}<br /></strong>, how<hr /> are you doing?
   </Trans>
 );

--- a/tests/__fixtures__/testTransComponent/nodeConversion.json
+++ b/tests/__fixtures__/testTransComponent/nodeConversion.json
@@ -8,8 +8,8 @@
   "expectValues": {
     "Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.": "",
     "Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>._plural": "",
-    "Hello <1>{{name}}</1>, you are strong.": "",
-    "Hi <1>{{name}}<1></1>, how<3> are you doing?": "",
+    "Hello <strong>{{name}}</strong>, you are strong.": "",
+    "Hi <1>{{name}}<br/></1>, how<3></3> are you doing?": "",
     "nameTitle": ""
   }
 }


### PR DESCRIPTION
@culshaw, could you check if this indeed fixes your issue?

---

In Trans components, tag names that are specified in "transKeepBasicHtmlNodesFor" should not be converted to indices when they have no attributes. As react-i18next actually sets a few tags in this option by default, not supporting this option was quite annoying. See https://react.i18next.com/latest/trans-component#additional-options-on-i-18-next-init

Also, it appeared that the conversion to indices was incorrect for self-closing tags such as `<hr />`. They were converted to `<0/>` when they should actually have been converted to `<0></0>`. However, self-closing tags present in `transKeepBasicHtmlNodesFor` must be converted to `<br/>` (and not `<br></br>`). This PR should make sure this is handled properly.

Fixes #83 