### PR TITLE
Get rid of automated deployment.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,26 +71,4 @@ stages:
                 inputs:
                   targetPath: lib/
                   artifactName: babel-plugin-i18next-extract
-  - stage: deploy
-    displayName: Deploy Project
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/releases/'))
-    jobs:
-      - template: .ci/templates/docker-jobs.yml
-        parameters:
-          jobs:
-            - job: deploy
-              displayName: Deploy to NPM
-              steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  path: lib/
-                  artifact: babel-plugin-i18next-extract
-              - script: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-                env:
-                  NPM_TOKEN: $(npm.token)
-              - script: |
-                  yarn version --non-interactive --new-version "${VERSION}" --no-git-tag-version
-                  yarn publish --non-interactive
-                env:
-                  VERSION: $(Build.SourceBranchName)
 


### PR DESCRIPTION
This stopped working at some point and introduce a slight security risk
should the token was compromised from the CI server at some point.

I'll do manual releases from now on.

Fixes #66 