### PR TITLE
Fix bad extracted keys with Trans and basic HTML nodes.

### DIFF
--- a/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.js
+++ b/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.js
@@ -14,7 +14,7 @@ const trans1 = (
   </Trans>
 );
 
-// Tag with attributes should not be converted to indices
+// Tags with attributes should not be converted to indices
 const trans2 = (
   <Trans>
     <p className="fizzBuzz">Trans 2</p>
@@ -24,6 +24,46 @@ const trans2 = (
 // Tags not set in config should be converted to indices
 const trans3 = (
   <Trans>
-    <strong>Trans 3<hr /></strong>
+    <strong>Trans 3</strong>
+  </Trans>
+);
+
+// Unnested tags should not be converted to indices
+const trans4 = (
+  <Trans>
+    <p>Trans 4</p>
+    <p></p>
+    <p>{"foo"}</p>
+    <p>{/* comment */}bar{/* comment */}</p>
+  </Trans>
+);
+
+// We should resolve identifiers
+const myString = "Trans 5";
+const trans5 = (
+  <Trans>
+    <p>{myString}</p>
+  </Trans>
+);
+
+// Interpolated variables should be converted to indices
+const trans6 = (
+  <Trans>
+    <p>{{myString}}</p>
+  </Trans>
+);
+
+// Multiple children should be converted to indices
+const trans7 = (
+  <Trans>
+    <p>Trans 7<hr /></p>
+  </Trans>
+);
+
+// Unresovable identifiers are converted to indices (arbitrarily)
+// They will be omitted in the export anyways.
+const trans8 = (
+  <Trans>
+    <p>{unresolvable}</p>
   </Trans>
 );

--- a/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.json
+++ b/tests/__fixtures__/testTransComponent/keepBasicHtmlNode.json
@@ -9,6 +9,10 @@
     "Trans<br/>0": "Trans<br/>0",
     "<p>Trans 1</p>": "<p>Trans 1</p>",
     "<0>Trans 2</0>": "<0>Trans 2</0>",
-    "<0>Trans 3<1></1></0>": "<0>Trans 3<1></1></0>"
+    "<0>Trans 3</0>": "<0>Trans 3</0>",
+    "<p>Trans 4</p><p></p><p>foo</p><p>bar</p>": "<p>Trans 4</p><p></p><p>foo</p><p>bar</p>",
+    "<p>Trans 5</p>": "<p>Trans 5</p>",
+    "<0>{{myString}}</0>": "<0>{{myString}}</0>",
+    "<0>Trans 7<1></1></0>": "<0>Trans 7<1></1></0>"
   }
 }

--- a/tests/__fixtures__/testTransComponent/nodeConversion.json
+++ b/tests/__fixtures__/testTransComponent/nodeConversion.json
@@ -8,7 +8,7 @@
   "expectValues": {
     "Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.": "",
     "Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>._plural": "",
-    "Hello <strong>{{name}}</strong>, you are strong.": "",
+    "Hello <1>{{name}}</1>, you are strong.": "",
     "Hi <1>{{name}}<br/></1>, how<3></3> are you doing?": "",
     "nameTitle": ""
   }


### PR DESCRIPTION
This commit adds a better heuristic to detect which Trans component will
be converted to indices by react-i18next (when using
transKeepBasicHtmlNodes which is enabled by default). In particular, if
the node has many children or interpolation, react-i18next ignores the
transKeepBasicHtmlNodes option and converts the node to indices.

Fixes #108

---

@pcorpet could you have a look? Does this indeed fix #108? It was quite complex to align with every edge-case statically, but this is the best heuristic I could make. I have not been able to fool it so far.