### PR TITLE
Clean up the exporter code to make it easier to use a different expor…

### DIFF
--- a/src/exporters/commons.ts
+++ b/src/exporters/commons.ts
@@ -47,6 +47,6 @@ export interface Exporter<F, K> {
     config: Config;
     file: F;
     key: TranslationKey;
-    value: string;
+    value: K;
   }) => F;
 }


### PR DESCRIPTION
…ter than JSONv3.

FYI, I'm starting a JSONv5 implementation. First to have the last trailing comma, but I'll try to get comments afterwards: comments that were initially in a file, or comments indicating the source of the extraction.

I believe this was the initial purpose of the design (having an easy way to select an exporter).