### PR TITLE
feat(config): outputPath function support

### DIFF
--- a/docs/templates/configuration.md.yml
+++ b/docs/templates/configuration.md.yml
@@ -179,10 +179,15 @@ configOptions:
           t("key0", {context: myCtx});
           ```
   - name: outputPath
-    type: "string"
+    type: "string | (locale: string, namespace: string) => string"
     description: |
-      Path where translation keys should be extracted to. You can use `{{ns}}` and `{{locale}}`
+      You can pass a string or a function as outputPath :
+
+      - **string**: Path where translation keys should be extracted to. You can use `{{ns}}` and `{{locale}}`
       placeholders in the value to change the location depending on the namespace or the locale.
+      - **function**: A function to return custom output path according to the given locale and namespace.
+
+      ⚠️ **outputPath** as function is only available for javascript babel config.
     defaultValue: "extractedTranslations/{{locale}}/{{ns}}.json"
   - name: defaultValue
     type: "string|null"

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export interface Config {
   i18nextInstanceNames: string[];
   tFunctionNames: string[];
   defaultContexts: string[];
-  outputPath: string;
+  outputPath: ((locale: string, namespace: string) => string) | string;
   defaultValue: string | null;
   useI18nextDefaultValue: boolean | string[];
   useI18nextDefaultValueForDerivedKeys: boolean;
@@ -78,10 +78,13 @@ export function parseConfig(opts: Partial<Config>): Config {
     ]),
     tFunctionNames: coalesce(opts.tFunctionNames, ['t']),
     defaultContexts: coalesce(opts.defaultContexts, ['', 'male', 'female']),
-    outputPath: coalesce(
-      opts.outputPath,
-      './extractedTranslations/{{locale}}/{{ns}}.json',
-    ),
+    outputPath:
+      typeof opts.outputPath === 'function'
+        ? opts.outputPath
+        : coalesce(
+            opts.outputPath,
+            './extractedTranslations/{{locale}}/{{ns}}.json',
+          ),
     defaultValue: coalesce(opts.defaultValue, ''),
     useI18nextDefaultValue: coalesce(
       opts.useI18nextDefaultValue,

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -116,9 +116,13 @@ export default function exportTranslationKeys(
 
   for (const key of keys) {
     // Figure out in which path each key should go.
-    const filePath = config.outputPath
-      .replace('{{locale}}', locale)
-      .replace('{{ns}}', key.ns);
+    const filePath =
+      typeof config.outputPath === 'function'
+        ? config.outputPath(locale, key.ns)
+        : config.outputPath
+            .replace('{{locale}}', locale)
+            .replace('{{ns}}', key.ns);
+
     keysPerFilepath[filePath] = [...(keysPerFilepath[filePath] || []), key];
   }
 

--- a/tests/__fixtures__/testConfig/outputPath.config.js
+++ b/tests/__fixtures__/testConfig/outputPath.config.js
@@ -1,0 +1,33 @@
+module.exports = {
+  "inputFiles": ["severalDomain.js"],
+  "description": "test that outputPath option as a function can return different path according to the given locale & namespace",
+  "pluginOptions": {
+    outputPath: (locale, namespace) => {
+      switch(namespace) {
+        case 'translation':
+          return `${__dirname}/.extracted/outputPath/custom/abc/${locale}/${namespace}.json`
+        case 'common':
+          return `${__dirname}/.extracted/outputPath/another/efg/${locale}/${namespace}.json`
+        default:
+      }
+    }
+  },
+  "expectValues": [
+    [
+      {
+        "anotherkey0": "",
+      },
+      {
+        "ns": "translation"
+      }
+    ],
+    [
+      {
+        "key0": "",
+      },
+      {
+        "ns": "common"
+      }
+    ]
+  ]
+}

--- a/tests/__fixtures__/testConfig/severalDomain.js
+++ b/tests/__fixtures__/testConfig/severalDomain.js
@@ -1,0 +1,2 @@
+i18next.t('common:key0');
+i18next.t('translation:anotherkey0');

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -53,15 +53,21 @@ function* genTestData(): IterableIterator<TestData> {
         withFileTypes: true,
       })
       .filter(
-        (testFile) => testFile.isFile() && testFile.name.endsWith('.json'),
+        (testFile) =>
+          testFile.isFile() &&
+          (testFile.name.endsWith('.json') ||
+            testFile.name.includes('config.js')),
       );
 
     for (const testFileEnt of testFilesEnt) {
       // testFile is a JSON file
       const testFile = path.join(testDir, testFileEnt.name);
-      const rawTestData = fs.readJSONSync(testFile, {
-        encoding: 'utf8',
-      });
+
+      const rawTestData = testFileEnt.name.includes('.config.js')
+        ? require(testFile)
+        : fs.readJSONSync(testFile, {
+            encoding: 'utf8',
+          });
       if (!Array.isArray(rawTestData.expectValues)) {
         rawTestData.expectValues = [[rawTestData.expectValues]];
       }
@@ -79,10 +85,14 @@ function* genTestData(): IterableIterator<TestData> {
         '.extracted',
         testFileEnt.name.replace(/\.json$/, ''),
       );
+
       const outputPath =
-        testData.pluginOptions && testData.pluginOptions.outputPath
-          ? path.join(extractionDir, testData.pluginOptions.outputPath)
-          : path.join(extractionDir, 'translations.{{ns}}.{{locale}}.json');
+        testData.pluginOptions &&
+        (typeof testData.pluginOptions.outputPath === 'function'
+          ? testData.pluginOptions.outputPath // returns a custom function
+          : typeof testData.pluginOptions.outputPath === 'string'
+          ? path.join(extractionDir, testData.pluginOptions.outputPath) // returns config value
+          : path.join(extractionDir, 'translations.{{ns}}.{{locale}}.json')); // returns default value
 
       rimraf(extractionDir);
 
@@ -103,13 +113,17 @@ function* genTestData(): IterableIterator<TestData> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function readExtractedFile(outputPath: string, opts?: ExpectKeysOpts): any {
+function readExtractedFile(
+  outputPath: ((locale: string, ns: string) => string) | string,
+  opts?: ExpectKeysOpts,
+): any {
   const ns = (opts && opts.ns) || 'translation';
   const locale = (opts && opts.locale) || 'en';
 
-  const realOutputPath = outputPath
-    .replace('{{ns}}', ns)
-    .replace('{{locale}}', locale);
+  const realOutputPath =
+    typeof outputPath === 'function'
+      ? outputPath(locale, ns)
+      : outputPath.replace('{{ns}}', ns).replace('{{locale}}', locale);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let extracted: any;
@@ -144,9 +158,17 @@ function assertHasExpectedValues(
     }
   }
   for (const [expected, opts] of testData.expectValues) {
+    const path =
+      typeof testData.pluginOptions.outputPath === 'function'
+        ? testData.pluginOptions.outputPath(
+            opts?.locale || 'en',
+            opts?.ns || 'translation',
+          )
+        : testData.pluginOptions.outputPath;
+
     const extracted = readExtractedFile(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      testData.pluginOptions.outputPath!,
+      path!,
       opts,
     );
     expect(extracted, `opts=${JSON.stringify(opts)}`).toEqual(expected);

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -56,7 +56,7 @@ function* genTestData(): IterableIterator<TestData> {
         (testFile) =>
           testFile.isFile() &&
           (testFile.name.endsWith('.json') ||
-            testFile.name.includes('config.js')),
+            testFile.name.includes('.config.js')),
       );
 
     for (const testFileEnt of testFilesEnt) {
@@ -86,13 +86,31 @@ function* genTestData(): IterableIterator<TestData> {
         testFileEnt.name.replace(/\.json$/, ''),
       );
 
-      const outputPath =
-        testData.pluginOptions &&
-        (typeof testData.pluginOptions.outputPath === 'function'
-          ? testData.pluginOptions.outputPath // returns a custom function
-          : typeof testData.pluginOptions.outputPath === 'string'
-          ? path.join(extractionDir, testData.pluginOptions.outputPath) // returns config value
-          : path.join(extractionDir, 'translations.{{ns}}.{{locale}}.json')); // returns default value
+      let outputPath;
+
+      if (testData.pluginOptions) {
+        if (typeof testData.pluginOptions.outputPath === 'function') {
+          // function from config
+          outputPath = testData.pluginOptions.outputPath;
+        }
+
+        if (
+          typeof testData.pluginOptions.outputPath === 'string' &&
+          !!testData.pluginOptions.outputPath
+        ) {
+          // value from config
+          outputPath = path.join(
+            extractionDir,
+            testData.pluginOptions.outputPath as string,
+          );
+        } else {
+          // no value provided from config
+          outputPath = path.join(
+            extractionDir,
+            'translations.{{ns}}.{{locale}}.json',
+          );
+        }
+      }
 
       rimraf(extractionDir);
 


### PR DESCRIPTION
# Feature 

## Request
Config: outputPath function support

### Expected 
I would like to have the control over the outputPath value so it can directly writes changes to a specific locale file.

```typescript
type outputPath = string | (locale: string, namespace: string) => string
```

### ℹ️   Important to consider
 **That option will only be available for javascript babel config file**

### Context & Usage 
In our application locales cannot be extracted into the same folder because they are shared across the app.
Its only after our build we copy every locales to the same folder (`public/locales/`)

**Example: Folder structure**
```
.
└── src/
    ├── locales/
    │   ├── en/
    │   └── fr/
    │       └── common.json
    ├── pages/
    │   └── Dashboard/
    │       └── locales/
    │           ├── en/
    │           └── fr/
    │               └── dashboard.json
    └── anotherFolder/
        └── locales/
            ├── en/
            └── fr/
                └── anotherFolder.json
```

**Example: babel.config.js**
```js
module.exports = {
  plugins: [
    [
      'i18next-extract',
      {
        locales: ['en', 'fr'],
        outputPath: (locale, namespace) => {
          const relPath = `src/**/*/locales/${locale}/${namespace}.json`
          const absPath = `${__dirname}/${relPath}`
          const results = glob.sync(absPath)

          if (!results.length) {
            throw new Error(`I18next: missing file in ${relPath}`)
          }

          return results[0]
        }
      }
    ]
  ],
}
```

