### PR TITLE
fix(exporter): fix cache overwriting changes to translation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@babel/core": "^7.11.6",
     "@babel/types": "7.9.6",
+    "deepmerge": "^4.2.2",
     "i18next": "^19.7.0",
     "json-stable-stringify": "^1.0.1"
   },

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -132,6 +132,10 @@ export default function exportTranslationKeys(
     cache.originalTranslationFiles[filePath] = deepmerge(
       cache.originalTranslationFiles[filePath] ?? {},
       loadTranslationFile(exporter, config, filePath),
+      {
+        // Overwrites the existing array values completely rather than concatenating them
+        arrayMerge: (dest, source) => source,
+      },
     );
 
     const originalTranslationFile = cache.originalTranslationFiles[filePath];

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -9,6 +9,9 @@ import jsonv3Exporter from './jsonv3';
 
 export { ConflictError, ExportError };
 
+function deepEqual(a: any, b: any): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
 /**
  * An instance of exporter cache.
  *
@@ -97,6 +100,26 @@ function getDefaultValue(
 }
 
 /**
+ * Return last modified date for the given file
+ *
+ * @param filePath
+ *
+ * @returns {Date|null}
+ */
+function getFileLastModified(filePath: string): Date | null {
+  let mtime;
+
+  try {
+    const stats = fs.statSync(filePath);
+    mtime = stats.mtime;
+  } catch (e) {
+    mtime = null;
+  }
+
+  return mtime;
+}
+
+/**
  * Exports all given translation keys as JSON.
  *
  * @param keys: translation keys to export
@@ -127,14 +150,25 @@ export default function exportTranslationKeys(
   }
 
   for (const [filePath, keysForFilepath] of Object.entries(keysPerFilepath)) {
-    if (!(filePath in cache.originalTranslationFiles)) {
+    const inCache = filePath in cache.originalTranslationFiles;
+    // get the mtime of the file
+    const lastModified = getFileLastModified(filePath);
+    // check if we already have a cached version of that file
+    // if there is one we compare the actual mtime with the one in the cache.
+    const localeFileHasChanged =
+      inCache &&
+      !!lastModified &&
+      !!cache.originalTranslationFiles[filePath].lastModified &&
+      cache.originalTranslationFiles[filePath].lastModified.getTime() !==
+        lastModified.getTime();
+
+    if (!inCache || localeFileHasChanged) {
       // Cache original translation file so that we don't loose it across babel
       // passes.
-      cache.originalTranslationFiles[filePath] = loadTranslationFile(
-        exporter,
-        config,
-        filePath,
-      );
+      cache.originalTranslationFiles[filePath] = {
+        lastModified: lastModified,
+        ...loadTranslationFile(exporter, config, filePath),
+      };
     }
 
     const originalTranslationFile = cache.originalTranslationFiles[filePath];
@@ -164,6 +198,16 @@ export default function exportTranslationKeys(
 
     cache.currentTranslationFiles[filePath] = translationFile;
 
+    // if no previous value it means its first time we go over that file
+    // if there is compare it with the old one
+    if (
+      !!cache.originalTranslationFiles[filePath].lastModified &&
+      !!translationFile &&
+      !!originalTranslationFile &&
+      deepEqual(translationFile, originalTranslationFile)
+    ) {
+      return;
+    }
     // Finally do the export
     const directoryPath = path.dirname(filePath);
     fs.mkdirSync(directoryPath, { recursive: true });

--- a/tests/exporters/exporter.test.ts
+++ b/tests/exporters/exporter.test.ts
@@ -89,7 +89,7 @@ describe('Test exporter works', () => {
     });
   });
 
-  it('can handle locale file update while processing (locale file disk change)', () => {
+  it('reload translation file and merge with actual cache', () => {
     const outputPath = path.join(outputDir, 'if_locale_file_changes.json');
     fs.writeJSONSync(outputPath, { presentAtInit: 'foo' });
 
@@ -121,31 +121,6 @@ describe('Test exporter works', () => {
     expect(fs.readJSONSync(outputPath)).toEqual({
       presentAtInit: 'foo updated directly in file after init',
       newKeyAfterInit: '',
-    });
-  });
-
-  it('should not update locale file cache when it does not change', () => {
-    const outputPath = path.join(outputDir, 'no_need_to_update_cache.json');
-    fs.writeJSONSync(outputPath, { presentAtInit: 'foo' });
-
-    const config = parseConfig({ outputPath });
-    const cache = createExporterCache();
-
-    // view key
-    const key0 = createTranslationKey('presentAtInit');
-
-    // extract at init
-    exportTranslationKeys([key0], 'fr', config, cache);
-    const { mtime } = fs.statSync(outputPath);
-
-    exportTranslationKeys([key0], 'fr', config, cache);
-
-    const { mtime: secondMtime } = fs.statSync(outputPath);
-
-    expect(mtime.getTime()).toEqual(secondMtime.getTime());
-
-    expect(fs.readJSONSync(outputPath)).toEqual({
-      presentAtInit: 'foo',
     });
   });
 });


### PR DESCRIPTION
fixes #78

Add caching abilities to check if :
- translation file as change and must be updated in cache (based on last modified time)
- if the old version does not equal the actual we update the translation file (base on `originalTranslationFile` & `translationFile variable`)

## Context

Environment: `development`
Tool:
* Webpack (with watch option)
* babel-loader
* babel-plugin-i18next-extract

## Expected

Our problem is the plugin re-write the translation file using the version it had at build time.

Example:

locale.json
```json
{
  "foo": ""
}
```
build ->  the plugin has the key 'foo' and the value ''

Inside locale.json I change the value of `foo` with `easy` and I save the file.

locale.json
```json
{
  "foo": "easy"
}
```
I add a key in my view named 'toto', the plugin extract that new key and add it inside our translation file.

theoretically locale.json should look like this
```json
{
  "foo": "easy",
  "toto": ""
}
```

but the plugin keeps the old version (version at the build time) and I got this:
```json
{
   "foo": "",
   "toto": ""
}
```

### Fixes

I have added : 
  * a check on the `mtime` of the file being processed 
  * a check to prevent from writing the translation file if it equals the old version

* [x] I have added unit test for those cases
* [ ] documentation (if needed)