### PR TITLE
Fix: ICU plural extraction produces invalid syntax

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -137,7 +137,7 @@ export function computeDerivedKeys(
         )
         .join(' ');
 
-      extractedKey.parsedOptions.defaultValue = `{count, plural, ${icuPlurals}`;
+      extractedKey.parsedOptions.defaultValue = `{count, plural, ${icuPlurals}}`;
     } else {
       if (numberOfPlurals === 1) {
         keys = keys.map((k) => ({

--- a/tests/__fixtures__/icu/icuPlurals.json
+++ b/tests/__fixtures__/icu/icuPlurals.json
@@ -7,7 +7,7 @@
   "expectValues": [
     [
       {
-        "foo": "{count, plural, one {The {count} item} other {The {count} item}"
+        "foo": "{count, plural, one {The {count} item} other {The {count} item}}"
       }
     ]
   ]


### PR DESCRIPTION
ICU plural extraction produces invalid value because of missing trailing `}`. It is not related to #184 even though it happens in same area.

This PR just simply adds the missing `}`

To double check if it is correct you can use https://devpal.co/icu-message-editor/ and copy the test fixture result in there