### PR TITLE
Ability to extract translations from objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ I'd be more than happy to merge it.
 
 If you've never contributed to a babel plugin before, the [Babel Plugin Handbook](
 https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md) is
-the place to start. Unfortuntely, the plugin API is not really well documented at the moment, so
+the place to start. Unfortunately, the plugin API is not really well documented at the moment, so
 you'll probably have to play around, dig into Babel source code and StackOverflow a bit. [
 AST Explorer](https://astexplorer.net/) might also be of help.
 

--- a/docs/templates/configuration.md.yml
+++ b/docs/templates/configuration.md.yml
@@ -335,3 +335,25 @@ configOptions:
       ☠️  *This feature is incomplete and might change or move into an third-party module in the
       future. Stay tuned.* ☠️
     defaultValue: "false"
+  - name: "translationKeys"
+    type: "string[]"
+    description: |
+      Enable extraction from object literals, based on the field name.
+      Useful when using translation function or component within a loop or dynamically.
+
+      Please define the translationKeys mindfully to avoid false positives.
+      Good examples: "i18Token", "i18nKey", "translationKey", "tKey"
+      Bad examples: "label", "token" (too generic, you might use those names in other contexts)
+
+    md: |
+      ```js
+      /*
+      { 
+        translationKeys: ["i18nToken"]
+      }
+      */
+
+      // Extracts "home": { "menu" }, "profile"
+      const menuItems = [{i18nToken: "home.menu", tabIndex: 0}, { i18nToken: "profile"}]
+      ```
+    defaultValue: null

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,11 +25,14 @@ export interface Config {
   enableExperimentalIcu: boolean;
   customTransComponents: readonly [string, string][];
   customUseTranslationHooks: readonly [string, string][];
+  translationKeys: string[] | null;
 
   // private cache
   cache: {
     absoluteCustomTransComponents: readonly [string, string][];
     absoluteCustomHooks: readonly [string, string][];
+    /** Translation keys list as a map for faster check */
+    translationKeysMap: { [key: string]: true } | null;
   };
 }
 
@@ -104,6 +107,7 @@ export function parseConfig(opts: Partial<Config>): Config {
     enableExperimentalIcu: coalesce(opts.enableExperimentalIcu, false),
     customTransComponents,
     customUseTranslationHooks,
+    translationKeys: coalesce(opts.translationKeys, null),
     cache: {
       absoluteCustomTransComponents: customTransComponents.map(
         ([sourceModule, importName]) => [
@@ -117,6 +121,12 @@ export function parseConfig(opts: Partial<Config>): Config {
           importName,
         ],
       ),
+      translationKeysMap: opts.translationKeys
+        ? opts.translationKeys.reduce(
+            (tKeyMap, tKey) => ({ ...tKeyMap, [tKey]: true }),
+            {},
+          )
+        : null,
     },
   };
 }

--- a/src/extractors/index.ts
+++ b/src/extractors/index.ts
@@ -5,6 +5,7 @@ import extractGetFixedTFunction from './getFixedTFunction';
 import extractI18nextInstance from './i18nextInstance';
 import extractTFunction from './tFunction';
 import extractTransComponent from './transComponent';
+import extractTranslationKey from './translationKey';
 import extractTranslationRenderProp from './translationRenderProp';
 import extractUseTranslationHook from './useTranslationHook';
 import extractWithTranslationHOC from './withTranslationHOC';
@@ -24,6 +25,7 @@ export const EXTRACTORS_PRIORITIES = [
   extractWithTranslationHOC.name,
   extractI18nextInstance.name,
   extractTFunction.name,
+  extractTranslationKey.name,
 ];
 
 export default {
@@ -36,4 +38,5 @@ export default {
   extractWithTranslationHOC,
   extractI18nextInstance,
   extractTFunction,
+  extractTranslationKey,
 };

--- a/src/extractors/translationKey.ts
+++ b/src/extractors/translationKey.ts
@@ -1,0 +1,76 @@
+/**
+ * Extracts translations stored in a JSON object
+ * Value of the extracted field is expected to represent arguments of t function
+ *
+ * Configuration: { }
+ *
+ * @example
+ * const menuItems = [
+ *   // Basic use case: the value of i18nToken field is the token
+ *   { i18nToken: "home.menu", path:"/" },
+ *   { i18nToken: "profile.menu", path: "/profile"}
+ *   // TODO: advanced use case, not yet supported
+ *   // The array correspond to arguments of the t function: t(...menuItemps[2].i18nToken)
+ *   {i18nToken: [["some.date", "another.fallback.key"], { date: "01/01/1970"}}
+ * ]
+ */
+
+import * as BabelCore from '@babel/core';
+import * as BabelTypes from '@babel/types';
+
+import { getCommentHintForPath, CommentHint } from '../comments';
+import { Config } from '../config';
+import { ExtractedKey } from '../keys';
+
+/**
+ * Parse a call expression (likely a call to a `t` function) to find its
+ * translation keys and i18next options.
+ *
+ * @param path: node path of the t function call.
+ * @param config: plugin configuration
+ * @param commentHints: parsed comment hints
+ */
+export default function extractTranslationKey(
+  path: BabelCore.NodePath<BabelTypes.ObjectExpression>,
+  config: Config,
+  commentHints: CommentHint[] = [],
+  //skipCheck = false,
+): ExtractedKey[] {
+  if (getCommentHintForPath(path, 'DISABLE', commentHints)) return [];
+  const translationKeysMap = config.cache.translationKeysMap;
+  if (!translationKeysMap) return []; // should not happen because we already disable this extractor in the plugin when there are no keys
+  const extractedKeys: ExtractedKey[] = [];
+  //if (!skipCheck && !isSimpleTCall(path, config)) return [];
+  const properties = path.get('properties');
+  properties.forEach((propertyPath) => {
+    if (propertyPath.isObjectProperty()) {
+      const keyPath = propertyPath.get('key');
+      if (Array.isArray(keyPath)) {
+        return;
+      }
+      const valuePath = propertyPath.get('value');
+      if (valuePath.isStringLiteral()) {
+        if (keyPath.isIdentifier()) {
+          const keyName = keyPath.node.name;
+          if (!translationKeysMap[keyName]) {
+            return;
+          }
+          // TODO: we can only handle basic string tokens currently, like: i18nToken: "foo.bar"
+          const stringKey = valuePath.node.value;
+          extractedKeys.push({
+            key: stringKey,
+            parsedOptions: {
+              contexts: false,
+              defaultValue: null,
+              hasCount: false,
+              ns: null,
+            },
+            sourceNodes: [path.node],
+            extractorName: extractTranslationKey.name,
+          });
+        }
+      }
+    }
+  });
+  return extractedKeys;
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -200,6 +200,23 @@ const Visitor: BabelCore.Visitor<VisitorState> = {
       );
     });
   },
+
+  ObjectExpression(path, state: VisitorState) {
+    const extractState = this.I18NextExtract;
+
+    // This check is costly, so ignore if translationKeys is not set in the config
+    if (!extractState.config.translationKeys) return;
+
+    handleExtraction(path, state, (collect) => {
+      collect(
+        Extractors.extractTranslationKey(
+          path,
+          extractState.config,
+          extractState.commentHints,
+        ),
+      );
+    });
+  },
 };
 
 export default function (

--- a/tests/__fixtures__/testTranslationKeys/simple.js
+++ b/tests/__fixtures__/testTranslationKeys/simple.js
@@ -1,0 +1,18 @@
+const menuItems = [{
+  i18nKey: "homeKey",
+  name: "Home Menu"
+}, {
+  i18nToken: "profile.menu",
+  tabIndex: 42
+}]
+
+export function MyComponent() {
+  const { t } = useTranslation()
+  return (
+    <ul>
+      <li>{t(menuItems[0].i18nKey)}</li>
+      <li>{t(menuItems[1].i18nToken)}</li>
+      <li>{t("logoutKey")}</li>
+    </ul>
+  );
+}

--- a/tests/__fixtures__/testTranslationKeys/simple.json
+++ b/tests/__fixtures__/testTranslationKeys/simple.json
@@ -1,0 +1,13 @@
+{
+  "description": "test simple extractions of tokens from an object",
+  "pluginOptions": {
+    "translationKeys": ["i18nToken", "i18nKey"]
+  },
+  "expectValues": {
+    "homeKey": "",
+    "profile": {
+      "menu": ""
+    },
+    "logoutKey": ""
+  }
+}


### PR DESCRIPTION
This PR brings an improvement to the "variable keys" scenarion (https://i18next-extract.netlify.app/#/faq?id=how-to-deal-with-variable-keys).

It lets you define object keys that will systematically be considered as i18n token. It works exactly like a `t` function call, with custom names for the function, but using an object field instead.

Limitations:
- it still throws a warning when you call the "t" function with the variable afterward `const myItem = { i18nToken: "foobar" }; t(myItem.i18nToken); // will trigger a false positive warning`
- it only supports the most basic scenario, of having just a key. So `{ i18nToken: "foobar"}` is supported but not `{ i18nToken: ["foobar", { someValue: 42 } ]`. It could be easily extended by considering the token value exactly like `t` function arguments but I am not familiar enough with both i18n and this plugin.