### PR TITLE
Fix empty transpiled file cache issue

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -204,14 +204,14 @@ const Visitor: BabelCore.Visitor<VisitorState> = {
   },
 };
 
+// This is a cache for the exporter to keep track of the translation files.
+// It must remain global and persist across transpiled files.
+const exporterCache = createExporterCache();
+
 export default function (
   api: BabelCore.ConfigAPI,
 ): BabelCore.PluginObj<VisitorState> {
   api.assertVersion(7);
-
-  // This is a cache for the exporter to keep track of the translation files.
-  // It must remain global and persist across transpiled files.
-  const exporterCache = createExporterCache();
 
   return {
     pre() {


### PR DESCRIPTION
To fix #208 
I found the `exporterCache` object doesn't persist across all the runs in newer babel versions(7.16.10+).
After some runs, it becomes empty. 
The solution is inspired by https://github.com/babel/babel/discussions/13590#discussioncomment-1034864
It points out that the cache object needs to be put outside the plugin function. (maybe we can also consider to use `weakMap` for the performance improvement.)

```js
post() {
      const extractState = this.I18NextExtract;
      if (extractState.extractedKeys.length === 0) return;
      console.log("exporterCache")
      console.log(exporterCache)
      // ... rest
},
```
|Before | After|
|---|---|
|![image](https://user-images.githubusercontent.com/6767433/182017717-490042dc-eac6-4a8a-89af-49fa8eb5303d.png)|![image](https://user-images.githubusercontent.com/6767433/182017805-956847cc-853e-456f-8b25-3a496fad25e4.png)|

Btw, thank you for the awesome plugin, it really helps our i18n flow a lot by reducing many manual steps! 🌟 🌟 🌟 