### PR TITLE
Fix plural issue with lang-region locale

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -153,7 +153,14 @@ export function computeDerivedKeys(
       throw unknownLocaleError;
     } else if (pluralRule instanceof Intl.PluralRules) {
       const pluralRulesOptions = pluralRule.resolvedOptions();
-      if (pluralRulesOptions.locale !== locale) {
+      // Node only returns the language part of the BCP 47 tag when resolving
+      // plural rules. We still need to check if the locale was properly
+      // resolved, but runtimes silently fallback to the user's locale when
+      // specifying a locale they don't know. Also, there doesn't seem to be a
+      // way to tell if a given locale is supported by the runtime or not. So
+      // as a workaround, we ensure that at least the language part of the
+      // resolved locale is consistent with the locale we want.
+      if (!locale.startsWith(pluralRulesOptions.locale)) {
         throw unknownLocaleError;
       }
       pluralCategories = pluralRulesOptions.pluralCategories;

--- a/tests/__fixtures__/testLocale/pluralsJSONv4.json
+++ b/tests/__fixtures__/testLocale/pluralsJSONv4.json
@@ -2,7 +2,7 @@
   "description": "plural tests in different languages",
   "comment": "ms has 1 plural, ak has 2 plurals, ar has 6 plurals",
   "pluginOptions": {
-    "locales": ["ak", "ar", "ms"],
+    "locales": ["ak", "ar", "ms", "zh-TW"],
     "compatibilityJSON": "v4"
   },
   "expectValues": [
@@ -17,6 +17,10 @@
     [
       {"myKey_other": ""},
       {"locale": "ms"}
+    ],
+    [
+      {"myKey_other": ""},
+      {"locale": "zh-TW"}
     ]
   ]
 }


### PR DESCRIPTION
To fix #256 

For {language}-{region} format locale, the plural count key can't be generated correctly.
The `locale` from the result of `pluralRule.resolvedOptions();` may only contain the language part, without the region.
Although the value of `locale` should be BCP 47 language tag, but node(only tested on v18.17) and some browsers don't support it yet. So I think we can also compare the language part of the locale.

On node v18.17
```js
const pluralRules = new Intl.PluralRules('en-US');
const options = pluralRules1.resolvedOptions();

console.log(options);
// output: Object { locale: "en", type: "cardinal",....}

```
