### PR TITLE
fix: don't use yarn to publish package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "build:js": "rollup -c",
     "test": "jest",
     "check": "${npm_execpath} run lint && ${npm_execpath} run types && ${npm_execpath} run test",
-    "release": "${npm_execpath} install && ${npm_execpath} run check && ${npm_execpath} run build && cd lib/ && ${npm_execpath} publish --no-git-tag-version"
+    "release": "${npm_execpath} install && ${npm_execpath} run check && ${npm_execpath} run build && cd lib/ && npm publish --no-git-tag-version"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Recent versions of yarn refuse to publish packages that don't have a yarn.lock and are located within an existing workspace. If we create an empty yarn.lock, yarn still insists on locking the dependencies, which we definitely don't want to include in the output package.

Always use npm to publish package. I guess using yarn for anything makes little sense nowadays, so we might just want to drop it entirely at some point.

See #260 