### PR TITLE
fix(ci): fix corepack setup fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.MAIN_NODE_VERSION }}
-          cache: 'yarn'
       - run: corepack enable
       - run: yarn install
       - run: yarn run lint
@@ -34,7 +33,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
       - run: corepack enable
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
CI was failing, probably because of a change in the setup-node action:
https://github.com/gilbsgilbs/babel-plugin-i18next-extract/actions/runs/7363053375/job/20042120587?pr=264

See also https://github.com/actions/setup-node/issues/480#issuecomment-1820622085