### PR TITLE
Fix: Add support to custom t names on custom translation hooks

### DIFF
--- a/src/extractors/useTranslationHook.ts
+++ b/src/extractors/useTranslationHook.ts
@@ -56,7 +56,11 @@ export default function extractUseTranslationHook(
 
   const id = parentPath.get('id');
 
-  const tBinding = id.scope.bindings['t'];
+  const tBindingKey =
+    config.tFunctionNames.find((name) => id.scope.bindings[name]) || 't';
+  if (!tBindingKey) return [];
+
+  const tBinding = id.scope.bindings[tBindingKey];
   if (!tBinding) return [];
 
   let keyPrefix: string | null = null;

--- a/tests/__fixtures__/testCustomHook/customNames.js
+++ b/tests/__fixtures__/testCustomHook/customNames.js
@@ -1,0 +1,26 @@
+import { useMyTranslation, useOtherTranslation } from './i18n';
+import { useThirdPartyTranslation } from 'third-party-module';
+import * as I18Next from 'third-party-module'
+
+export function MyComponent0() {
+	const [_] = useMyTranslation('ns0');
+	return <p>{_('key0')}{_('key1')}</p>
+}
+
+export function MyComponent1() {
+	const [iceT] = useOtherTranslation(['ns1', 'noob']);
+	return <p>{iceT('key in ns1')}</p>
+}
+
+export function MyComponent2() {
+	const { translate } = I18Next.useThirdPartyTranslation('ns2');
+	someFunc(translate);
+	return <p>{translate('key in ns2')}</p>
+}
+
+export function MyComponent3() {
+	const foo = 'noob';
+	// i18next-extract-mark-ns-next-line ns3
+	const [myT] = useThirdPartyTranslation(foo);
+	return <p>{myT('key in ns3')}</p>
+}

--- a/tests/__fixtures__/testCustomHook/customNames.json
+++ b/tests/__fixtures__/testCustomHook/customNames.json
@@ -1,0 +1,17 @@
+{
+  "description": "test custom useTranslation hooks giving custom instance name to t function",
+  "pluginOptions": {
+    "customUseTranslationHooks": [
+      ["./tests/__fixtures__/testCustomHook/i18n", "useMyTranslation"],
+      ["./tests/__fixtures__/testCustomHook/i18n", "useOtherTranslation"],
+      ["third-party-module", "useThirdPartyTranslation"]
+    ],
+    "tFunctionNames": ["_", "iceT", "myT", "translate"]
+  },
+  "expectValues": [
+    [{ "key0": "", "key1": "" }, { "ns": "ns0" }],
+    [{ "key in ns1": "" }, { "ns": "ns1" }],
+    [{ "key in ns2": "" }, { "ns": "ns2" }],
+    [{ "key in ns3": "" }, { "ns": "ns3" }]
+  ]
+}


### PR DESCRIPTION
Using custom `t` names combined with custom translation hooks is not working as expected.
For example, the translation keys will not be extracted:
```JSX
function MyComponent() {
  const { myTranslationFunction } = useMyTranslationHook('namespace');

  return <p>{myTranslationFunction('myTranslationKey')}</p>;
}
```

After some investigation, I found this is due to a hardcoded `"t"` key inside the `useTranslationHook` extractor:

https://github.com/gilbsgilbs/babel-plugin-i18next-extract/blob/7cc5b807de142bedabcacb234ecc167e9db343a1/src/extractors/useTranslationHook.ts#L59

This PR adds some simple logic to try out different function names in the order they are defined in the `tFunctionNames` configuration parameter